### PR TITLE
Add the remote URL example back in

### DIFF
--- a/Simple Universal Webview App/ViewController.swift
+++ b/Simple Universal Webview App/ViewController.swift
@@ -26,6 +26,10 @@ class ViewController: UIViewController {
 
         // Create url request from local index.html file located in web_content
         let url: NSURL = NSBundle.mainBundle().URLForResource("web_content/index", withExtension: "html")!
+        
+        // Create a url request that points to a remote server (uncomment this line to use a remote url)
+        // let url: NSURL = NSURL (string: "http://example.com")!;
+
         let requestObj: NSURLRequest = NSURLRequest(URL: url);
         
         // Test operating system


### PR DESCRIPTION
The README has a comment that we can "switch around the commented out URL lines" but there is no second URL line provided as an example.
